### PR TITLE
Fix second rollover issue - CRTs

### DIFF
--- a/UserDev/EventDisplay/RawViewer/DrawFEBData.cxx
+++ b/UserDev/EventDisplay/RawViewer/DrawFEBData.cxx
@@ -46,13 +46,14 @@ bool DrawFEBData::analyze(const gallery::Event & ev) {
     const auto& tdcs
         = ev.getValidHandle<std::vector<sbnd::timing::DAQTimestamp> >(tdc_data_tag);
 
-    uint64_t etrig_time = 0;
+    uint32_t etrig_s = 0, etrig_ns = 0;
 
     for(auto const& tdc : *tdcs)
       {
 	if(tdc.Channel() == 4)
 	  {
-	    etrig_time = tdc.Timestamp() % static_cast<uint64_t>(1e9);
+	    etrig_s  = tdc.Timestamp() / static_cast<uint64_t>(1e9);
+	    etrig_ns = tdc.Timestamp() % static_cast<uint64_t>(1e9);
 	  }
       }
 
@@ -66,7 +67,23 @@ bool DrawFEBData::analyze(const gallery::Event & ev) {
 
         // Take the T0 time (time since PPS) reference to to the event trigger
         // and apply stored cable delay in Coinc field.
-        int64_t t0 = (int64_t)feb.Ts0() - etrig_time + feb.Coinc();
+        int64_t t0 = (int64_t)feb.Ts0() + feb.Coinc();
+
+        uint32_t feb_unixs = (uint32_t) feb.UnixS();
+        int64_t unix_diff = static_cast<int64_t>(etrig_s) - static_cast<int64_t>(feb_unixs);
+
+        if(unix_diff < -1 || unix_diff > 1)
+          {
+            throw std::runtime_error(Form("Unix timestamps differ by more than 1 (%li)", unix_diff));
+          }
+
+        if(unix_diff == 1)
+          t0 -= 1e9;
+        else if(unix_diff == -1)
+          t0 += 1e9;
+
+        t0 -= etrig_ns;
+
         uint32_t t1 = feb.Ts1();
 
         const auto& adc_arr = feb.ADC();


### PR DESCRIPTION
In the DrawFEBData functionality we reference the CRT time to the event trigger time saved in the TDC product (such that 0 ~= the event trigger time).

Michelle discovered an issue that I traced down to having resulted from not properly accounting for occasions where the etrig and (some) of the CRT data are recorded in different full seconds (can't just view the nanosecond component).

The code is modelled on the code used in the offline reconstruction to do the same thing (can be found [here](https://github.com/SBNSoftware/sbndcode/blob/develop/sbndcode/CRT/CRTReco/CRTStripHitProducer_module.cc#L216-L238)

I tested on a handful of events. Here is one... 

Before:
![Screenshot from 2025-07-02 16-27-31](https://github.com/user-attachments/assets/13c8389a-1af9-4b1a-ba1f-6180cbd5610f)

After:
![Screenshot from 2025-07-02 16-19-21](https://github.com/user-attachments/assets/ec3b46e4-4d81-41eb-87c0-e4c4c88e8e16)

Note the increased range of CRT data out to the full 50ms.
