### PR TITLE
Hotfix/icarus plane labels

### DIFF
--- a/UserDev/EventDisplay/python/titus/drawables/drawable.py
+++ b/UserDev/EventDisplay/python/titus/drawables/drawable.py
@@ -50,7 +50,7 @@ class Drawable:
 
         if self._producer_name == _NULL_NAME:
             return
-        
+
         self._process.analyze(self._gi.event_handle())
 
     def set_producer(self, producer):
@@ -78,7 +78,7 @@ class Drawable:
                     self._process.addInput(p)
             else:
                 self._process.setInput(str(producer))
-        
+
         self._producer_name = producer
 
     def init(self):

--- a/UserDev/EventDisplay/python/titus/gallery_interface/geometry.py
+++ b/UserDev/EventDisplay/python/titus/gallery_interface/geometry.py
@@ -466,7 +466,6 @@ class sbnd(Geometry):
         self._levels = [(100, -10), (-10, 100), (-10, 200)]
 
         self._view_names = ['U', 'V', 'Y']
-        # self._plane_mix = {0: [4], 1: [3], 2: [5]}
         self._plane_mix = {0: [3], 1: [4], 2: [5]}
         self._plane_flip = [False, False, False, True, True, True]
         self._plane_shift = [False, False, False, False, False, False]
@@ -567,9 +566,8 @@ class icarus(Geometry):
         self.configure(geometryCore, detProperties, readoutProperties, detClocks, lar_properties, auxDetGeometryCore)
 
         self._pedestals = [0, 0, 0, 0, 0, 0]
-        self._levels = [(100, 0), (0, 100), (0, 100), (100, 0), (0, 100), (0, 100)]
+        self._levels = [(40000, 0), (0, 40000), (0, 40000), (40000, 0), (0, 40000), (0, 40000)]
         self._view_names = ['H', 'U', 'V']
-        # self._plane_mix = {0: [3, 6, 9], 1: [5, 8, 11], 2: [4, 7, 10]}
         self._plane_mix = {0: [3], 1: [5], 2: [4], 6: [9], 7: [11], 8: [10]}
         self._plane_flip = [False, False, False, True, True, True, False, False, False, True, True, True]
 

--- a/UserDev/EventDisplay/python/titus/gallery_interface/geometry.py
+++ b/UserDev/EventDisplay/python/titus/gallery_interface/geometry.py
@@ -217,7 +217,7 @@ class geoBase(object):
 
     def getAuxDetGeometryCore(self):
         return self._auxDetGeometryCore
-    
+
     def getGeometryCore(self):
         return self._geometryCore
 
@@ -367,9 +367,9 @@ class Geometry(geoBase):
         self._wireReadout = readoutProperties #We have two names for this now
         self._auxDetGeometryCore = auxDetGeometryCore
 
-        self._halfwidth = geometryCore.Cryostat(0).HalfWidth()
-        self._halfheight = geometryCore.Cryostat(0).HalfHeight()
-        self._length = geometryCore.Cryostat(0).Length()
+        self._halfwidth = geometryCore.TPC().HalfWidth()
+        self._halfheight = geometryCore.TPC().HalfHeight()
+        self._length = geometryCore.TPC().Length()
         #self._time2Cm = detProperties.SamplingRate() / 1000.0 * detProperties.DriftVelocity(detProperties.Efield(), detProperties.Temperature())
         self._time2Cm = self._detectorClocks.TPCClock().TickPeriod() * self._detectorProperties.DriftVelocity(self._detectorProperties.Efield(), self._detectorProperties.Temperature())
         self._wire2Cm = readoutProperties.Plane(ROOT.geo.TPCID(0, 0), 0).WirePitch()

--- a/UserDev/EventDisplay/python/titus/modules/tpc_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/tpc_module.py
@@ -1494,7 +1494,7 @@ class WireView(pg.GraphicsLayoutWidget):
             # Take into account the distance between planes
             offset = self._geometry.triggerOffset() * self._geometry.time2cm() # - delta_plane
 
-            x_cathode = (self._geometry.halfwidth() + offset)/self._geometry.time2cm()
+            x_cathode = (2.0 * self._geometry.halfwidth() + offset)/self._geometry.time2cm()
             x_anode   = offset / self._geometry.time2cm()
 
             # If we are changing the t0, shift the anode and cathode position
@@ -1542,7 +1542,7 @@ class WireView(pg.GraphicsLayoutWidget):
         self._removed_entries = 0
 
         if self._uniteCathodes:
-            x_cathode = (self._geometry.halfwidth() + self._geometry.offset(self._plane))/self._geometry.time2cm()
+            x_cathode = (2.0 * self._geometry.halfwidth() + self._geometry.offset(self._plane))/self._geometry.time2cm()
             x_anode   = 0 + self._geometry.offset(self._plane)/self._geometry.time2cm()
 
             x_cathode += self._manual_t0

--- a/UserDev/EventDisplay/python/titus/modules/tpc_module.py
+++ b/UserDev/EventDisplay/python/titus/modules/tpc_module.py
@@ -297,7 +297,7 @@ class TpcModule(Module):
             default_products = self._gi.get_default_products(_RECOB_CHANNELROI)
             self._channel_roi_choice = MultiSelectionBox(self, _RECOB_CHANNELROI, products, default_products)
             self._channel_roi_choice.activated.connect(self.change_wire_choice)
-            
+
             wire_choice_layout.addWidget(self._channel_roi_button, 3, 0, 1, 1)
             wire_choice_layout.addWidget(self._channel_roi_choice, 3, 1, 1, 1)
             self._channel_roi_choice.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
@@ -788,7 +788,7 @@ class TpcModule(Module):
             if producers is not None:
                 producer = producers
             elif self._gm.current_geom.name() == 'icarus' and len(all_producers) > 3:
-                producer = [p.full_name() for p in all_producers[:3]]
+                producer = [p.full_name() for p in all_producers[:4]]
             else:
                 producer = self._wire_choice.selected_products()[0]
 
@@ -1264,8 +1264,8 @@ class WireView(pg.GraphicsLayoutWidget):
         self._viewport_name_low.setStyleSheet('color: rgb(169,169,169);')
         self._viewport_name_low.setMaximumWidth(25)
 
-        self._geometry.planeMix()[plane][0] - self._geometry.nPlanes()
-        name = f'TPC West, Plane {plane}'
+        self._other_plane = self._geometry.planeMix()[plane][0] % self._geometry.nPlanes()
+        name = f'TPC West, Plane {self._other_plane}'
         self._viewport_name_up = VerticalLabel(name)
         self._viewport_name_up.setStyleSheet('color: rgb(169,169,169);')
         self._viewport_name_up.setMaximumWidth(25)
@@ -1482,6 +1482,7 @@ class WireView(pg.GraphicsLayoutWidget):
         Draws lines corresponding to the cathode and anode positions for t0 = 0
         Red line = anode
         Blue line = cathode
+        use ticks, since that's how the array is stored
         '''
 
         if not self._showAnodeCathode:
@@ -1493,9 +1494,8 @@ class WireView(pg.GraphicsLayoutWidget):
             # Take into account the distance between planes
             offset = self._geometry.triggerOffset() * self._geometry.time2cm() # - delta_plane
 
-            hw = 100
-            x_cathode = (2 * self._geometry.halfwidth() + offset)/self._geometry.time2cm()
-            x_anode   = offset/self._geometry.time2cm()
+            x_cathode = (self._geometry.halfwidth() + offset)/self._geometry.time2cm()
+            x_anode   = offset / self._geometry.time2cm()
 
             # If we are changing the t0, shift the anode and cathode position
             x_cathode += self._manual_t0
@@ -1506,7 +1506,6 @@ class WireView(pg.GraphicsLayoutWidget):
                 x_cathode = self._geometry.tRange() - x_cathode
                 x_anode   = self._geometry.tRange() - x_anode
 
-
             # Add the ad-hoc gap between TPCs
             x_cathode += tpc * self._geometry.cathodeGap()
             x_anode   += tpc * self._geometry.cathodeGap()
@@ -1516,9 +1515,8 @@ class WireView(pg.GraphicsLayoutWidget):
             x_anode   += tpc * self._geometry.tRange()
 
             # If we are deleting entries to see the cathodes together, do it here too
-            x_cathode = x_cathode - 2 * tpc * self._removed_entries
-            x_anode   = x_anode - 2 * tpc * self._removed_entries
-
+            x_cathode -= 2 * tpc * self._removed_entries
+            x_anode   -= 2 * tpc * self._removed_entries
 
             # Construct the cathode line and append it
             line = QtWidgets.QGraphicsLineItem()
@@ -1544,8 +1542,7 @@ class WireView(pg.GraphicsLayoutWidget):
         self._removed_entries = 0
 
         if self._uniteCathodes:
-
-            x_cathode = (2 * self._geometry.halfwidth() + self._geometry.offset(self._plane))/self._geometry.time2cm()
+            x_cathode = (self._geometry.halfwidth() + self._geometry.offset(self._plane))/self._geometry.time2cm()
             x_anode   = 0 + self._geometry.offset(self._plane)/self._geometry.time2cm()
 
             x_cathode += self._manual_t0
@@ -1570,7 +1567,7 @@ class WireView(pg.GraphicsLayoutWidget):
 
             data = np.delete(data, final_slice, axis=1)
             self.drawPlane(data)
-        
+
         self.drawPlane(data)
         self.showAnodeCathode(self._showAnodeCathode)
 
@@ -1609,7 +1606,7 @@ class WireView(pg.GraphicsLayoutWidget):
             else:
                 message += "W: "
                 message += str(int(self.q.x()))
-        
+
         if self._cmSpace:
             if type(message) != str:
                 message.append(", Y: ")
@@ -1669,18 +1666,15 @@ class WireView(pg.GraphicsLayoutWidget):
             data = self._item.image
             if wire < 0 or wire >= len(data):
                 return
-            
+
             self._wireData = data[wire]
             self._wireData = self._wireData[self._first_entry:self._last_entry]
 
             # Here we want to display the real plane number, not the view.
             # So, make sure that if you are in an odd TPC we display the right number.
             plane = self._plane
-            if tpc %2 != 0:
-                if self._plane == 0:
-                    plane = 1
-                elif self._plane == 1:
-                    plane = 0
+            if tpc % 2 != 0:
+                plane = self._other_plane
 
             self._wdf(wireData=self._wireData, wire=wire, plane=plane, tpc=tpc,\
                       cryo=self._cryostat, drawer=self, replace_idx=replace_idx)


### PR DESCRIPTION
Fix a couple bugs:
- ICARUS EW TPC was not always drawn
- ICARUS plane label in wire waveform view was incorrectly swapped
- Anode&cathode positions were incorrectly positioned after the v10 upgrade